### PR TITLE
Fix polling task not being cancelled

### DIFF
--- a/iOCNotes/Store.swift
+++ b/iOCNotes/Store.swift
@@ -18,7 +18,6 @@ final class Store: Logging, Storing {
     /// The currently active login flow polling task.
     ///
     var pollingTask: Task<Void, any Error>?
-    var pollingToken: String?
 
     ///
     /// This singleton is necessary to conveniently expose the same environment object used in SwiftUI to the already existing UIKit code.
@@ -333,16 +332,11 @@ final class Store: Logging, Storing {
                     logger.debug("Cancelling previous polling task before starting a new one.")
                     pollingTask.cancel()
                     self.pollingTask = nil
-                    self.pollingToken = nil
                 }
 
-                self.pollingToken = token
                 self.pollingTask = Task { @MainActor in
                     defer {
-                        if self.pollingToken == token {
-                            self.pollingTask = nil
-                            self.pollingToken = nil
-                        }
+                        self.pollingTask = nil
                     }
 
                     repeat {
@@ -379,7 +373,6 @@ final class Store: Logging, Storing {
 
         pollingTask.cancel()
         self.pollingTask = nil
-        pollingToken = nil
         logger.debug("Polling task cancelled.")
     }
 }

--- a/iOCNotes/Store.swift
+++ b/iOCNotes/Store.swift
@@ -15,9 +15,10 @@ final class Store: Logging, Storing {
     ///
     /// Required for `ServerAddressViewDelegate` conformance.
     ///
-    /// Tasks are keyed by their login flow polling token.
+    /// The currently active login flow polling task.
     ///
-    var pollingTasks = [String: Task<Void, any Error>]()
+    var pollingTask: Task<Void, any Error>?
+    var pollingToken: String?
 
     ///
     /// This singleton is necessary to conveniently expose the same environment object used in SwiftUI to the already existing UIKit code.
@@ -328,8 +329,24 @@ final class Store: Logging, Storing {
 
                 logger.debug("Received login address \"\(loginAddress)\" with polling endpoint \"\(endpoint)\" and token \"\(token)\".")
 
-                self.pollingTasks[token] = Task { @MainActor in
+                if let pollingTask {
+                    logger.debug("Cancelling previous polling task before starting a new one.")
+                    pollingTask.cancel()
+                    self.pollingTask = nil
+                    self.pollingToken = nil
+                }
+
+                self.pollingToken = token
+                self.pollingTask = Task { @MainActor in
+                    defer {
+                        if self.pollingToken == token {
+                            self.pollingTask = nil
+                            self.pollingToken = nil
+                        }
+                    }
+
                     repeat {
+                        try Task.checkCancellation()
                         grantValues = await getResponse(endpoint: endpoint, token: token, options: options)
                         try await Task.sleep(for: .seconds(1))
                     } while grantValues == nil
@@ -352,16 +369,17 @@ final class Store: Logging, Storing {
         }
     }
 
-    func cancelPolling(by token: String) {
-        logger.debug("Cancelling polling task by token \"\(token)\"...")
+    func cancelPolling() {
+        logger.debug("Cancelling polling task.")
 
-        guard let task = pollingTasks[token] else {
-            logger.error("Attempt to cancel polling task by token \"\(token)\" which is not registered!")
+        guard let pollingTask else {
+            logger.error("Attempt to cancel polling task but no task is active!")
             return
         }
 
-        task.cancel()
-        pollingTasks.removeValue(forKey: token)
-        logger.debug("Polling task cancelled by token \"\(token)\".")
+        pollingTask.cancel()
+        self.pollingTask = nil
+        pollingToken = nil
+        logger.debug("Polling task cancelled.")
     }
 }

--- a/iOCNotes/Views/ContentView.swift
+++ b/iOCNotes/Views/ContentView.swift
@@ -39,8 +39,8 @@ struct ContentView: View {
                 store.addAccount(host: host, name: name, password: password)
             } beginPolling: { url, _ in
                try await store.beginPolling(at: url)
-            } cancelPolling: { token in
-                store.cancelPolling(by: token)
+            } cancelPolling: {
+                store.cancelPolling()
             }
             .onAppear {
                 // The store must update its list of shared accounts when the login user interface is about to appear.


### PR DESCRIPTION
- Use a single login task as we only ever need one.
- Remove token from `stopPolling` as we do not need it.
- Also fixes `stopPolling` not being called.