### PR TITLE
feat: add favorites management to the notes list

### DIFF
--- a/Networking/NoteSessionManager.swift
+++ b/Networking/NoteSessionManager.swift
@@ -515,13 +515,13 @@ class NoteSessionManager {
         }
     }
 
-    func update(note: NoteProtocol, completion: SyncCompletionBlock? = nil) {
+    func update(note: NoteProtocol, updateModified: Bool = true, completion: SyncCompletionBlock? = nil) {
         logger.notice("Updating note...")
 
         var incoming = note
         incoming.updateNeeded = true
         if NoteSessionManager.isOnline {
-            updateOnServer(incoming) { [weak self] result in
+            updateOnServer(incoming, updateModified: updateModified) { [weak self] result in
                 switch result {
                 case .success( _):
                     completion?()
@@ -538,11 +538,14 @@ class NoteSessionManager {
         }
     }
     
-    fileprivate func updateOnServer(_ note: NoteProtocol, handler: @escaping SyncHandler) {
+    fileprivate func updateOnServer(_ note: NoteProtocol, updateModified: Bool = true, handler: @escaping SyncHandler) {
+        // Metadata-only changes (e.g. toggling favorite) keep the existing modification date so the note does
+        // not jump to the top of a date-sorted list and the row is not re-sorted a second time after the sync.
+        let modified = updateModified ? Date().timeIntervalSince1970 : note.modified
         let parameters: Parameters = ["title": note.title as Any,
                                       "content": note.content as Any,
                                       "category": note.category as Any,
-                                      "modified": Date().timeIntervalSince1970 as Any,
+                                      "modified": modified as Any,
                                       "favorite": note.favorite]
         let router = Router.updateNote(id: Int(note.id), paramters: parameters)
         session

--- a/iOCNotes/Views/NotesListModel.swift
+++ b/iOCNotes/Views/NotesListModel.swift
@@ -10,16 +10,26 @@ import SwiftUI
 /// Immutable values needed to identify, render and act on a note list row.
 ///
 struct NoteListRow: Equatable, Identifiable {
+    ///
+    /// Identity used by the native list, which must replace a swiped row when favorite sorting moves it.
+    ///
+    struct PresentationID: Hashable {
+        let noteID: NSManagedObjectID
+        let favorite: Bool
+    }
+
     private static let snippetLength = 512
 
-    let id: NSManagedObjectID
+    let noteID: NSManagedObjectID
     let title: String
     let snippet: String
     let modified: Double
     let favorite: Bool
 
+    var id: PresentationID { PresentationID(noteID: noteID, favorite: favorite) }
+
     init(note: Note) {
-        id = note.objectID
+        noteID = note.objectID
         title = note.title
         snippet = Self.snippet(from: note.content)
         modified = note.modified
@@ -63,6 +73,7 @@ final class NotesListModel: NSObject, Logging, NSFetchedResultsControllerDelegat
 
     @ObservationIgnored private var fetchedResultsController: NSFetchedResultsController<Note>?
     @ObservationIgnored private var searchText = ""
+    @ObservationIgnored private var pendingFavoriteRowReplacement = false
     private var collapsedTitles: Set<String>
 
     private(set) var groupByCategory: Bool
@@ -185,11 +196,28 @@ final class NotesListModel: NSObject, Logging, NSFetchedResultsControllerDelegat
         try? NotesData.mainThreadContext.existingObject(with: id) as? Note
     }
 
+    func toggleFavorite(for id: NSManagedObjectID) -> Note? {
+        guard let note = note(for: id) else { return nil }
+        pendingFavoriteRowReplacement = true
+        note.favorite.toggle()
+        return note
+    }
+
     // MARK: - NSFetchedResultsControllerDelegate
 
     @objc
     func controllerDidChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
-        rebuildSections()
+        guard pendingFavoriteRowReplacement else {
+            rebuildSections()
+            return
+        }
+
+        pendingFavoriteRowReplacement = false
+        var transaction = Transaction()
+        transaction.disablesAnimations = true
+        withTransaction(transaction) {
+            rebuildSections()
+        }
     }
 }
 

--- a/iOCNotes/Views/NotesListModel.swift
+++ b/iOCNotes/Views/NotesListModel.swift
@@ -122,14 +122,17 @@ final class NotesListModel: NSObject, Logging, NSFetchedResultsControllerDelegat
         request.predicate = predicate(for: searchText)
 
         if groupByCategory {
+            // "category" must stay first so it matches the section key path; favorites float to the top within each category.
             request.sortDescriptors = [
                 NSSortDescriptor(key: "category", ascending: true),
+                NSSortDescriptor(key: "favorite", ascending: false),
                 NSSortDescriptor(key: "modified", ascending: false),
                 NSSortDescriptor(key: "id", ascending: true),
                 NSSortDescriptor(key: "guid", ascending: true)
             ]
         } else {
             request.sortDescriptors = [
+                NSSortDescriptor(key: "favorite", ascending: false),
                 NSSortDescriptor(key: "modified", ascending: false),
                 NSSortDescriptor(key: "id", ascending: true),
                 NSSortDescriptor(key: "guid", ascending: true)

--- a/iOCNotes/Views/NotesListView.swift
+++ b/iOCNotes/Views/NotesListView.swift
@@ -81,6 +81,14 @@ struct NotesListView: View {
             .contextMenu {
                 contextMenu(for: row)
             }
+            .swipeActions(edge: .leading) {
+                Button {
+                    toggleFavorite(row)
+                } label: {
+                    favoriteLabel(isFavorite: row.favorite)
+                }
+                .tint(.yellow)
+            }
             .swipeActions(edge: .trailing) {
                 Button(role: .destructive) {
                     delete(row)
@@ -108,6 +116,12 @@ struct NotesListView: View {
             } label: {
                 Label(String(localized: "Category…", comment: "Action to change category of a note"), systemImage: "folder")
             }
+        }
+
+        Button {
+            toggleFavorite(row)
+        } label: {
+            favoriteLabel(isFavorite: row.favorite)
         }
 
         Button {
@@ -148,6 +162,21 @@ struct NotesListView: View {
     private func delete(_ row: NoteListRow) {
         guard let note = model.note(for: row.id) else { return }
         NoteSessionManager.shared.delete(note: note)
+    }
+
+    @ViewBuilder
+    private func favoriteLabel(isFavorite: Bool) -> some View {
+        if isFavorite {
+            Label(String(localized: "Remove from Favorites", comment: "Action to unmark a note as favorite"), systemImage: "star.slash")
+        } else {
+            Label(String(localized: "Favorite", comment: "Action to mark a note as favorite"), systemImage: "star")
+        }
+    }
+
+    private func toggleFavorite(_ row: NoteListRow) {
+        guard let note = model.note(for: row.id) else { return }
+        note.favorite.toggle()
+        NoteSessionManager.shared.update(note: note, completion: nil)
     }
 
     private func commitRename() {

--- a/iOCNotes/Views/NotesListView.swift
+++ b/iOCNotes/Views/NotesListView.swift
@@ -104,7 +104,7 @@ struct NotesListView: View {
         if canRename {
             Button {
                 renameText = row.title
-                noteToRename = row.id
+                noteToRename = row.noteID
             } label: {
                 Label(String(localized: "Rename…", comment: "Action to change title of a note"), systemImage: "square.and.pencil")
             }
@@ -145,22 +145,22 @@ struct NotesListView: View {
     }
 
     private func openEditor(for row: NoteListRow) {
-        guard let note = model.note(for: row.id) else { return }
+        guard let note = model.note(for: row.noteID) else { return }
         NotesPresenter.openEditor(for: note, isNewNote: false)
     }
 
     private func openCategories(for row: NoteListRow) {
-        guard let note = model.note(for: row.id) else { return }
+        guard let note = model.note(for: row.noteID) else { return }
         NotesPresenter.openCategories(for: note, categories: Note.categories() ?? [])
     }
 
     private func share(_ row: NoteListRow) {
-        guard let note = model.note(for: row.id) else { return }
+        guard let note = model.note(for: row.noteID) else { return }
         NotesPresenter.share(note: note, exporter: &exporter)
     }
 
     private func delete(_ row: NoteListRow) {
-        guard let note = model.note(for: row.id) else { return }
+        guard let note = model.note(for: row.noteID) else { return }
         NoteSessionManager.shared.delete(note: note)
     }
 
@@ -174,8 +174,7 @@ struct NotesListView: View {
     }
 
     private func toggleFavorite(_ row: NoteListRow) {
-        guard let note = model.note(for: row.id) else { return }
-        note.favorite.toggle()
+        guard let note = model.toggleFavorite(for: row.noteID) else { return }
         NoteSessionManager.shared.update(note: note, updateModified: false, completion: nil)
     }
 

--- a/iOCNotes/Views/NotesListView.swift
+++ b/iOCNotes/Views/NotesListView.swift
@@ -176,7 +176,7 @@ struct NotesListView: View {
     private func toggleFavorite(_ row: NoteListRow) {
         guard let note = model.note(for: row.id) else { return }
         note.favorite.toggle()
-        NoteSessionManager.shared.update(note: note, completion: nil)
+        NoteSessionManager.shared.update(note: note, updateModified: false, completion: nil)
     }
 
     private func commitRename() {


### PR DESCRIPTION
Implements favorites management in the SwiftUI notes list (#52):

- Toggle a note's favorite state via a leading swipe action and the context menu
- Sort favorites to the top within the current sort mode (top of the list when sorting by most recent, first within each category when grouped)
- The favorite indicator was already rendered per row

The data model, persistence and network payloads already carried `favorite`, so this is UI-only.

Stacked on #189 (SwiftUI notes list redesign); please merge that first. Base this PR against `feature/swiftui-notes-list`.

Closes #52