### PR TITLE
fix: report login flow completion and errors

### DIFF
--- a/iOCNotes/Store.swift
+++ b/iOCNotes/Store.swift
@@ -19,6 +19,9 @@ final class Store: Logging, Storing {
     ///
     var pollingTask: Task<Void, any Error>?
 
+    /// A terminal error reported by the active login flow.
+    var loginErrorMessage: String?
+
     ///
     /// This singleton is necessary to conveniently expose the same environment object used in SwiftUI to the already existing UIKit code.
     ///
@@ -289,31 +292,45 @@ final class Store: Logging, Storing {
         }
     }
 
-    private func getResponse(endpoint: URL, token: String, options: NKRequestOptions) async -> (url: String, user: String, appPassword: String)? {
+    private func getResponse(endpoint: URL, token: String, options: NKRequestOptions) async throws -> (url: String, user: String, appPassword: String)? {
         logger.debug("Getting login flow status...")
 
-        return await withCheckedContinuation { continuation in
-            NextcloudKit.shared.getLoginFlowV2Poll(token: token, endpoint: endpoint.absoluteString, options: options) { [self] server, loginName, appPassword, _, error in
+        return try await withCheckedThrowingContinuation { continuation in
+            NextcloudKit.shared.getLoginFlowV2Poll(token: token, endpoint: endpoint.absoluteString, options: options) { [self] server, loginName, appPassword, response, error in
                 if error == .success, let urlBase = server, let user = loginName, let appPassword {
                     logger.debug("Successfully got login flow status (server: \(urlBase), user: \(user), password: \(appPassword)).")
                     continuation.resume(returning: (urlBase, user, appPassword))
-                } else {
-                    logger.debug("Failed to get login flow status.")
+                } else if response?.response?.statusCode == 404 {
+                    logger.debug("Login flow is pending.")
                     continuation.resume(returning: nil)
+                } else {
+                    logger.error("Failed to get login flow status: \(error.localizedDescription, privacy: .public)")
+                    continuation.resume(throwing: error.error)
                 }
             }
         }
     }
 
-    func beginPolling(at url: URL) async throws -> URL {
+    private func getLoginFlow(for url: URL) async throws -> (endpoint: URL, login: URL, token: String) {
+        let options = NKRequestOptions(customUserAgent: userAgent)
+
+        do {
+            return try await NextcloudKit.shared.getLoginFlowV2(serverUrl: url.absoluteString, options: options)
+        } catch {
+            logger.error("Failed to start login flow: \(error.localizedDescription, privacy: .public)")
+            throw error
+        }
+    }
+
+    func beginPolling(at url: URL, dismiss: @MainActor @Sendable @escaping () -> Void) async throws -> URL {
         logger.debug("Beginning polling at \(url.absoluteString)")
+        loginErrorMessage = nil
 
         let (_, serverInfoResult) = await NextcloudKit.shared.getServerStatusAsync(serverUrl: url.absoluteString)
 
         switch serverInfoResult {
             case .success:
-                let loginOptions = NKRequestOptions(customUserAgent: userAgent)
-                let (endpoint, loginAddress, token) = try await NextcloudKit.shared.getLoginFlowV2(serverUrl: url.absoluteString, options: loginOptions)
+                let (endpoint, loginAddress, token) = try await getLoginFlow(for: url)
                 let options = NKRequestOptions(customUserAgent: userAgent)
                 var grantValues: (url: String, user: String, appPassword: String)?
 
@@ -330,21 +347,33 @@ final class Store: Logging, Storing {
                         self.pollingTask = nil
                     }
 
-                    repeat {
-                        try Task.checkCancellation()
-                        grantValues = await getResponse(endpoint: endpoint, token: token, options: options)
-                        try await Task.sleep(for: .seconds(1))
-                    } while grantValues == nil
+                    do {
+                        repeat {
+                            try Task.checkCancellation()
+                            grantValues = try await getResponse(endpoint: endpoint, token: token, options: options)
 
-                    guard let grantValues else {
-                        return
+                            if grantValues == nil {
+                                try await Task.sleep(for: .seconds(1))
+                            }
+                        } while grantValues == nil
+
+                        guard let grantValues else {
+                            return
+                        }
+
+                        guard let host = URL(string: grantValues.url) else {
+                            throw NKError.urlError.error
+                        }
+
+                        addAccount(host: host, name: grantValues.user, password: grantValues.appPassword)
+                        dismiss()
+                    } catch is CancellationError {
+                        logger.debug("Login flow polling was cancelled.")
+                    } catch {
+                        logger.error("Login flow polling failed: \(error.localizedDescription, privacy: .public)")
+                        loginErrorMessage = error.localizedDescription
+                        dismiss()
                     }
-
-                    guard let host = URL(string: grantValues.url) else {
-                        return
-                    }
-
-                    addAccount(host: host, name: grantValues.user, password: grantValues.appPassword)
                 }
 
                 return loginAddress
@@ -358,7 +387,7 @@ final class Store: Logging, Storing {
         logger.debug("Cancelling polling task.")
 
         guard let pollingTask else {
-            logger.error("Attempt to cancel polling task but no task is active!")
+            logger.debug("No active polling task to cancel.")
             return
         }
 

--- a/iOCNotes/Views/ContentView.swift
+++ b/iOCNotes/Views/ContentView.swift
@@ -37,14 +37,28 @@ struct ContentView: View {
         if store.accounts.isEmpty {
             ServerAddressView(backgroundColor: .constant(Color.accent), brandImage: Image("BrandLogo"), sharedAccounts: sharedAccounts, userAgent: userAgent) { host, name, password in
                 store.addAccount(host: host, name: name, password: password)
-            } beginPolling: { url, _ in
-               try await store.beginPolling(at: url)
+            } beginPolling: { url, dismiss in
+                try await store.beginPolling(at: url, dismiss: dismiss)
             } cancelPolling: {
                 store.cancelPolling()
             }
             .onAppear {
                 // The store must update its list of shared accounts when the login user interface is about to appear.
                 store.readSharedAccounts()
+            }
+            .alert("Login Failed", isPresented: Binding(
+                get: { store.loginErrorMessage != nil },
+                set: { isPresented in
+                    if isPresented == false {
+                        store.loginErrorMessage = nil
+                    }
+                }
+            )) {
+                Button("OK", role: .cancel) {
+                    store.loginErrorMessage = nil
+                }
+            } message: {
+                Text(store.loginErrorMessage ?? "Unknown login error.")
             }
 
         } else {


### PR DESCRIPTION
## What changed

- Pass the login UI dismissal callback through to the polling flow and invoke it after successful account creation.
- Treat HTTP 404 from the Login Flow v2 polling endpoint as the expected pending state.
- Stop retrying terminal polling failures and present them in a `Login Failed` alert.
- Log Login Flow v2 startup and polling failures with useful error details.
- Treat cancellation without an active polling task as an expected condition.

## Why

The host app discarded the dismissal callback supplied by `ServerAddressView`, so a successful login was not explicitly reported back to the login UI. Polling also collapsed every unsuccessful response into a pending state, causing terminal server or network errors to retry indefinitely without visible feedback.

## Impact

Successful browser-based login now closes the login UI and proceeds into the app. Expected pending responses remain silent, while genuine polling failures stop the flow and give the user an actionable error alert.

## Validation

- Built the `iOCNotes` scheme successfully for an iPhone 17 Pro simulator running iOS 27.0.
- Installed and launched the resulting app in the simulator.
- Confirmed the app process remained running without a launch failure.